### PR TITLE
Added a leaderboard page to display user rankings based on cash

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,8 +72,15 @@ def leaderboard():
     else:
         title = "Cash Ranking"
         value_label = "Cash"
-        
-    return render_template("leaderboard.html")
+
+    return render_template(
+        "leaderboard.html",
+        users=users,
+        title=title,
+        ranking_type=ranking_type,
+        value_label=value_label,
+        current_user=session["user"]
+    )
 
 
 # logout

--- a/app.py
+++ b/app.py
@@ -60,6 +60,12 @@ def dashboard():
 def leaderboard():
     if "user" not in session:
         return redirect("/login")
+    
+    ranking_type = request.args.get("type", "cash")
+
+    # Since user model only has cash attribute, both cash and total assets use cash temporarily
+    users = User.query.order_by(User.cash.desc()).all()
+
     return render_template("leaderboard.html")
 
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, request, redirect, session, flash
 from db import init_db
 from models import db, User
+from leaderboard import get_leaderboard_context
 import hashlib
 
 app = Flask(__name__)
@@ -93,32 +94,11 @@ def leaderboard():
         return redirect("/login")
     
     ranking_type = request.args.get("type", "cash")
-
-    # Since user model only has cash attribute, both cash and total assets use cash temporarily
-    # users = User.query.order_by(User.cash.desc()).all()
-
-    # Mock data for demonstration
-    users = [
-    {"username": "Alice", "cash": 12500},
-    {"username": "Bob", "cash": 11800},
-    {"username": session["user"], "cash": 10950},
-    {"username": "Charlie", "cash": 9500}
-    ]
-
-    if ranking_type == "assets":
-        title = "Total Assets Ranking"
-        value_label = "Total Assets"
-    else:
-        title = "Cash Ranking"
-        value_label = "Cash"
+    context = get_leaderboard_context(ranking_type, session["user"])
 
     return render_template(
         "leaderboard.html",
-        users=users,
-        title=title,
-        ranking_type=ranking_type,
-        value_label=value_label,
-        current_user=session["user"]
+        **context
     )
 
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, render_template, request, redirect, session, flash
-
+#from model import User
 app = Flask(__name__)
 app.secret_key = "secret123"
 
@@ -64,7 +64,15 @@ def leaderboard():
     ranking_type = request.args.get("type", "cash")
 
     # Since user model only has cash attribute, both cash and total assets use cash temporarily
-    users = User.query.order_by(User.cash.desc()).all()
+    # users = User.query.order_by(User.cash.desc()).all()
+
+    # Mock data for demonstration
+    users = [
+    {"username": "Alice", "cash": 12500},
+    {"username": "Bob", "cash": 11800},
+    {"username": session["user"], "cash": 10950},
+    {"username": "Charlie", "cash": 9500}
+    ]
 
     if ranking_type == "assets":
         title = "Total Assets Ranking"

--- a/app.py
+++ b/app.py
@@ -66,6 +66,13 @@ def leaderboard():
     # Since user model only has cash attribute, both cash and total assets use cash temporarily
     users = User.query.order_by(User.cash.desc()).all()
 
+    if ranking_type == "assets":
+        title = "Total Assets Ranking"
+        value_label = "Total Assets"
+    else:
+        title = "Cash Ranking"
+        value_label = "Cash"
+        
     return render_template("leaderboard.html")
 
 

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -1,0 +1,20 @@
+from models import User
+
+def get_leaderboard_context(ranking_type, current_user):
+
+    leaderboard_users = User.query.order_by(User.cash.desc()).all()
+
+    if ranking_type == "assets":
+        title = "Total Assets Ranking"
+        value_label = "Total Assets"
+    else:
+        title = "Cash Ranking"
+        value_label = "Cash"
+
+    return {
+        "users": leaderboard_users,
+        "title": title,
+        "ranking_type": ranking_type,
+        "value_label": value_label,
+        "current_user": current_user
+    }

--- a/static/css/leaderboard.css
+++ b/static/css/leaderboard.css
@@ -196,3 +196,28 @@ tr:hover {
     font-size: 0.85rem;
 }
 
+@media (max-width: 640px) {
+    .leaderboard-page {
+        padding: 14px;
+    }
+
+    .user-panel {
+        width: 100%;
+        justify-content: space-between;
+        flex-wrap: wrap;
+    }
+
+    .user-links {
+        width: 100%;
+        justify-content: flex-end;
+    }
+
+    .ranking-tabs {
+        width: 100%;
+    }
+
+    .ranking-tab {
+        flex: 1;
+        text-align: center;
+    }
+}

--- a/static/css/leaderboard.css
+++ b/static/css/leaderboard.css
@@ -30,6 +30,16 @@ body {
     z-index: 0;
 }
 
+.leaderboard-page {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 16px;
+    padding: 20px;
+    max-width: 1280px;
+    margin: 0 auto;
+}
+
 .panel {
     background: var(--panel);
     border: 1px solid var(--line);

--- a/static/css/leaderboard.css
+++ b/static/css/leaderboard.css
@@ -103,6 +103,54 @@ body {
     color: var(--ink);
 }
 
+h1 {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.8vw, 2rem);
+}
+
+h2 {
+    margin: 0 0 6px;
+    font-size: 1.05rem;
+}
+
+.leaderboard-panel {
+    overflow: hidden;
+}
+
+.section-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+}
+
+.muted-text {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.92rem;
+}
+
+.ranking-tabs {
+    display: flex;
+    gap: 8px;
+}
+
+.ranking-tab {
+    border: 1px solid var(--line);
+    background: white;
+    color: var(--ink);
+    border-radius: 999px;
+    padding: 8px 14px;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.ranking-tab.active {
+    background: var(--ink);
+    color: white;
+}
 
 .card {
     border-radius: 12px;

--- a/static/css/leaderboard.css
+++ b/static/css/leaderboard.css
@@ -55,20 +55,54 @@ body {
     margin: 0 0 4px;
 }
 
-.leaderboard-header {
-    background-color: white;
-    padding: 24px;
-    border-radius: 12px;
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
-.leaderboard-header h1 {
-    margin-bottom: 10px;
+.user-panel {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 14px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.72);
 }
 
-.leaderboard-header p {
-    color: #666;
-    margin-bottom: 0;
+.welcome-text {
+    margin: 0;
+    font-weight: 600;
+    color: var(--ink);
 }
+
+.user-links {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.action-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 34px;
+    padding: 0 12px;
+    border-radius: 999px;
+    background: var(--ink);
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.action-link.secondary {
+    background: rgba(20, 53, 67, 0.1);
+    color: var(--ink);
+}
+
 
 .card {
     border-radius: 12px;

--- a/static/css/leaderboard.css
+++ b/static/css/leaderboard.css
@@ -1,60 +1,136 @@
+:root {
+    --bg-1: #f6fbff;
+    --bg-2: #e8f5f0;
+    --ink: #143543;
+    --muted: #5f7b86;
+    --panel: rgba(255, 255, 255, 0.82);
+    --line: rgba(20, 53, 67, 0.14);
+    --buy: #0c9e6c;
+    --sell: #d94a4a;
+    --up: #0b9c67;
+    --down: #cc3d57;
+}
+
+* {
+    box-sizing: border-box;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    background-color: #f5f7fa;
     margin: 0;
+    font-family: "Avenir Next", "Segoe UI", sans-serif;
+    color: var(--ink);
+    background: radial-gradient(circle at 10% 10%, #ffffff 0%, var(--bg-1) 40%, var(--bg-2) 100%);
+}
+
+.dashboard-bg {
+    position: fixed;
+    inset: 0;
+    background-image: linear-gradient(120deg, rgba(12, 158, 108, 0.08) 0%, rgba(19, 73, 125, 0.07) 100%);
+    pointer-events: none;
+    z-index: 0;
+}
+
+.panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 16px;
+    backdrop-filter: blur(8px);
+    box-shadow: 0 10px 24px rgba(21, 45, 64, 0.08);
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: var(--muted);
+    margin: 0 0 4px;
+}
+
+.leaderboard-header {
+    background-color: white;
+    padding: 24px;
+    border-radius: 12px;
+}
+
+.leaderboard-header h1 {
+    margin-bottom: 10px;
+}
+
+.leaderboard-header p {
+    color: #666;
+    margin-bottom: 0;
+}
+
+.card {
+    border-radius: 12px;
+}
+
+.table th {
+    background-color: #2c3e50;
+    color: white;
 }
 
 .container {
+    background-color: white;
     width: 60%;
     margin: 50px auto;
     text-align: center;
 }
 
-h1 {
+/* h1 {
     margin-bottom: 20px;
-}
+} */
 
-.buttons {
+/* .buttons {
     margin-bottom: 20px;
-}
+} */
 
-button {
+/* button {
     padding: 10px 20px;
     border: none;
     margin: 5px;
     cursor: pointer;
     border-radius: 5px;
     background-color: #ddd;
-}
+} */
 
-button.active {
+/* button.active {
     background-color: #4CAF50;
     color: white;
-}
+} */
 
-table {
+/* table {
     width: 100%;
     border-collapse: collapse;
     background: white;
     border-radius: 8px;
     overflow: hidden;
-}
+} */
 
-th, td {
+/* th, td {
     padding: 12px;
     border-bottom: 1px solid #eee;
-}
+} */
 
-th {
+/* th {
     background-color: #4CAF50;
     color: white;
-}
+} */
 
-tr:hover {
+/* tr:hover {
     background-color: #f1f1f1;
-}
+} */
 
 .current-user {
-    background-color: #ffeeba;
+    background-color: #fff3cd;
     font-weight: bold;
 }

--- a/static/css/leaderboard.css
+++ b/static/css/leaderboard.css
@@ -152,67 +152,47 @@ h2 {
     color: white;
 }
 
-.card {
-    border-radius: 12px;
+.table-wrap {
+    overflow-x: auto;
 }
 
-.table th {
-    background-color: #2c3e50;
-    color: white;
-}
-
-.container {
-    background-color: white;
-    width: 60%;
-    margin: 50px auto;
-    text-align: center;
-}
-
-/* h1 {
-    margin-bottom: 20px;
-} */
-
-/* .buttons {
-    margin-bottom: 20px;
-} */
-
-/* button {
-    padding: 10px 20px;
-    border: none;
-    margin: 5px;
-    cursor: pointer;
-    border-radius: 5px;
-    background-color: #ddd;
-} */
-
-/* button.active {
-    background-color: #4CAF50;
-    color: white;
-} */
-
-/* table {
+table {
     width: 100%;
     border-collapse: collapse;
-    background: white;
-    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.72);
+    border-radius: 12px;
     overflow: hidden;
-} */
+}
 
-/* th, td {
-    padding: 12px;
-    border-bottom: 1px solid #eee;
-} */
+th,
+td {
+    text-align: left;
+    padding: 12px 10px;
+    border-bottom: 1px solid var(--line);
+}
 
-/* th {
-    background-color: #4CAF50;
-    color: white;
-} */
+th {
+    color: var(--ink);
+    font-weight: 700;
+}
 
-/* tr:hover {
-    background-color: #f1f1f1;
-} */
+tr:hover {
+    background: rgba(20, 53, 67, 0.04);
+}
 
 .current-user {
-    background-color: #fff3cd;
-    font-weight: bold;
+    background: rgba(12, 158, 108, 0.1) !important;
+    font-weight: 700;
 }
+
+.asset-label {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(12, 158, 108, 0.12);
+    color: var(--buy);
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -19,9 +19,16 @@
     
     <h2 class="text-center mb-3">{{ title }}</h2>
 
-    <div class="buttons">
-        <button class="active">Total Assets</button>
-        <button>Cash</button>
+    <div class="text-center mb-4">
+        <a href="{{ url_for('leaderboard', type='assets') }}"
+           class="btn {% if ranking_type == 'assets' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+            Total Assets
+        </a>
+
+        <a href="{{ url_for('leaderboard', type='cash') }}"
+           class="btn {% if ranking_type == 'cash' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+            Cash
+        </a>
     </div>
 
     <table>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -73,7 +73,7 @@
                                         {{ loop.index }}
                                     {% endif %}
                                 </td>
-
+                                <!-- Use the hardcoded user data -->
                                 <td>{{ user.username }}</td>
                                 <td>${{ "{:,.2f}".format(user.cash) }}</td>
                             </tr>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -37,12 +37,12 @@
 
                 <div class="ranking-tabs">
                     <a href="{{ url_for('leaderboard', type='assets') }}"
-                        class="btn {% if ranking_type == 'assets' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                        class="ranking-tab {% if ranking_type == 'assets' %}active{% else %}inactive{% endif %}">
                         Total Assets
                     </a>
 
                     <a href="{{ url_for('leaderboard', type='cash') }}"
-                        class="btn {% if ranking_type == 'cash' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                        class="ranking-tab {% if ranking_type == 'cash' %}btn-primary{% else %}btn-outline-primary{% endif %}">
                         Cash
                     </a>
                 </div>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -3,7 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Leaderboard</title>
-    <link rel="stylesheet" href="../static/css/leaderboard.css">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/leaderboard.css') }}">
 </head>
 <body>
 

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -78,6 +78,14 @@
             </div>
         </div>
     </div>
+    
+    # Back to dashboard button
+    <div class="text-center mt-4">
+        <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">
+            Back to Dashboard
+        </a>
+    </div>
+    
 </div>          
 </body>
 </html>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -2,14 +2,32 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Leaderboard</title>
-
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/leaderboard.css') }}">
 </head>
 <body>
+    <div class="dashboard-bg"></div>
+
+    <main class="leaderboard-page">
+        <header class="page-header panel">
+            <div>
+                <p class="kicker">Trading Rankings</p>
+                <h1>🏆 Leaderboard</h1>
+            </div>
+
+            <div class="header-actions">
+                <div class="user-panel">
+                    <p class="welcome-text">Welcome {{ session["user"] }}</p>
+                    <div class="user-links">
+                        <a class="action-link secondary" href="/dashboard">Dashboard</a>
+                        <a class="action-link" href="/logout">Logout</a>
+                    </div>
+                </div>
+            </div>
+        </header>
+    </main>
 
 <div class="container mt-5">
     <div class="leaderboard-header text-center mb-4">
@@ -45,10 +63,11 @@
                     <tbody>
                         {% if users %}
                             {% for user in users %}
-                            # Highlight the current user's row
-                            <tr class="{% if user.username == current_user %}current-user{% endif %}">
+                            <!-- Highlight the current user's row -->
+                            <!-- <tr class="{% if user.username == current_user %}current-user{% endif %}"> -->
+                            <tr class="{% if user['username'] == current_user %}current-user{% endif %}">
                                 <td>
-                                    # Display medals for top 3 ranks, otherwise show rank number
+                                    <!-- Display medals for top 3 ranks, otherwise show rank number -->
                                     {% if loop.index == 1 %}
                                         🥇 1
                                     {% elif loop.index == 2 %}
@@ -60,16 +79,18 @@
                                     {% endif %}
                                 </td>
 
-                                # Display the username
+                                <!-- Display the username -->
+                                <!-- <td>{{ user.username }}</td> -->
                                 <td>{{ user.username }}</td>
 
-                                # Format the value with commas and 2 decimal places
+                                <!-- Format the value with commas and 2 decimal places -->
+                                <!-- <td>${{ "{:,.2f}".format(user.cash) }}</td> -->
                                 <td>${{ "{:,.2f}".format(user.cash) }}</td>
                             </tr>
                             {% endfor %}
                         {% else %}
                             <tr>
-                                # If there are no users, show a message
+                                <!-- If there are no users, show a message -->
                                 <td colspan="4">No users available.</td>
                             </tr>
                         {% endif %}
@@ -79,13 +100,13 @@
         </div>
     </div>
     
-    # Back to dashboard button
+    <!-- Back to dashboard button -->
     <div class="text-center mt-4">
         <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">
             Back to Dashboard
         </a>
     </div>
-    
+
 </div>          
 </body>
 </html>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -27,32 +27,29 @@
                 </div>
             </div>
         </header>
-    </main>
 
-<div class="container mt-5">
-    <div class="leaderboard-header text-center mb-4">
-        <h1>🏆 Leaderboard</h1>
-        <p>Compare users by cash and total assets</p>
-    </div>
-    
-    <h2 class="text-center mb-3">{{ title }}</h2>
+        <section class="panel leaderboard-panel">
+            <div class="section-head">
+                <div>
+                    <h2>{{ title }}</h2>
+                    <p class="muted-text">Compare users by cash and total assets</p>
+                </div>
 
-    <div class="text-center mb-4">
-        <a href="{{ url_for('leaderboard', type='assets') }}"
-           class="btn {% if ranking_type == 'assets' %}btn-primary{% else %}btn-outline-primary{% endif %}">
-            Total Assets
-        </a>
+                <div class="ranking-tabs">
+                    <a href="{{ url_for('leaderboard', type='assets') }}"
+                        class="btn {% if ranking_type == 'assets' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                        Total Assets
+                    </a>
 
-        <a href="{{ url_for('leaderboard', type='cash') }}"
-           class="btn {% if ranking_type == 'cash' %}btn-primary{% else %}btn-outline-primary{% endif %}">
-            Cash
-        </a>
-    </div>
+                    <a href="{{ url_for('leaderboard', type='cash') }}"
+                        class="btn {% if ranking_type == 'cash' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                        Cash
+                    </a>
+                </div>
+            </div>
 
-    <div class="card shadow-sm">
-        <div class="card-body">
-            <div class="table-responsive">
-                <table class="table table-striped table-hover text-center mb-0">
+            <div class="table-wrap">
+                <table>
                     <thead>
                         <tr>
                             <th>Rank</th>
@@ -60,14 +57,12 @@
                             <th>{{ value_label }} ($)</th>
                         </tr>
                     </thead>
+
                     <tbody>
                         {% if users %}
                             {% for user in users %}
-                            <!-- Highlight the current user's row -->
-                            <!-- <tr class="{% if user.username == current_user %}current-user{% endif %}"> -->
-                            <tr class="{% if user['username'] == current_user %}current-user{% endif %}">
+                            <tr class="{% if user.username == current_user %}current-user{% endif %}">
                                 <td>
-                                    <!-- Display medals for top 3 ranks, otherwise show rank number -->
                                     {% if loop.index == 1 %}
                                         🥇 1
                                     {% elif loop.index == 2 %}
@@ -79,34 +74,19 @@
                                     {% endif %}
                                 </td>
 
-                                <!-- Display the username -->
-                                <!-- <td>{{ user.username }}</td> -->
                                 <td>{{ user.username }}</td>
-
-                                <!-- Format the value with commas and 2 decimal places -->
-                                <!-- <td>${{ "{:,.2f}".format(user.cash) }}</td> -->
                                 <td>${{ "{:,.2f}".format(user.cash) }}</td>
                             </tr>
                             {% endfor %}
                         {% else %}
                             <tr>
-                                <!-- If there are no users, show a message -->
                                 <td colspan="4">No users available.</td>
                             </tr>
                         {% endif %}
                     </tbody>
                 </table>
             </div>
-        </div>
-    </div>
-    
-    <!-- Back to dashboard button -->
-    <div class="text-center mt-4">
-        <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">
-            Back to Dashboard
-        </a>
-    </div>
-
-</div>          
+        </section>
+    </main>      
 </body>
 </html>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -80,7 +80,7 @@
                             {% endfor %}
                         {% else %}
                             <tr>
-                                <td colspan="4">No users available.</td>
+                                <td colspan="3">No users available.</td>
                             </tr>
                         {% endif %}
                     </tbody>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -31,38 +31,53 @@
         </a>
     </div>
 
-    <table>
-        <thead>
-            <tr>
-                <th>Rank</th>
-                <th>User</th>
-                <th>Value ($)</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>🥇 1</td>
-                <td>Alice</td>
-                <td>12,500</td>
-            </tr>
-            <tr>
-                <td>🥈 2</td>
-                <td>Bob</td>
-                <td>11,800</td>
-            </tr>
-            <tr class="current-user">
-                <td>🥉 3</td>
-                <td>You</td>
-                <td>10,950</td>
-            </tr>
-            <tr>
-                <td>4</td>
-                <td>Charlie</td>
-                <td>9,500</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover text-center mb-0">
+                    <thead>
+                        <tr>
+                            <th>Rank</th>
+                            <th>User</th>
+                            <th>{{ value_label }} ($)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% if users %}
+                            {% for user in users %}
+                            # Highlight the current user's row
+                            <tr class="{% if user.username == current_user %}current-user{% endif %}">
+                                <td>
+                                    # Display medals for top 3 ranks, otherwise show rank number
+                                    {% if loop.index == 1 %}
+                                        🥇 1
+                                    {% elif loop.index == 2 %}
+                                        🥈 2
+                                    {% elif loop.index == 3 %}
+                                        🥉 3
+                                    {% else %}
+                                        {{ loop.index }}
+                                    {% endif %}
+                                </td>
 
+                                # Display the username
+                                <td>{{ user.username }}</td>
+
+                                # Format the value with commas and 2 decimal places
+                                <td>${{ "{:,.2f}".format(user.cash) }}</td>
+                            </tr>
+                            {% endfor %}
+                        {% else %}
+                            <tr>
+                                # If there are no users, show a message
+                                <td colspan="4">No users available.</td>
+                            </tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>          
 </body>
 </html>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -11,8 +11,13 @@
 </head>
 <body>
 
-<div class="container">
-    <h1>🏆 Leaderboard</h1>
+<div class="container mt-5">
+    <div class="leaderboard-header text-center mb-4">
+        <h1>🏆 Leaderboard</h1>
+        <p>Compare users by cash and total assets</p>
+    </div>
+    
+    <h2 class="text-center mb-3">{{ title }}</h2>
 
     <div class="buttons">
         <button class="active">Total Assets</button>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -37,12 +37,12 @@
 
                 <div class="ranking-tabs">
                     <a href="{{ url_for('leaderboard', type='assets') }}"
-                        class="ranking-tab {% if ranking_type == 'assets' %}active{% else %}inactive{% endif %}">
+                        class="ranking-tab {% if ranking_type == 'assets' %}active{% endif %}">
                         Total Assets
                     </a>
 
                     <a href="{{ url_for('leaderboard', type='cash') }}"
-                        class="ranking-tab {% if ranking_type == 'cash' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                        class="ranking-tab {% if ranking_type == 'cash' %}active{% endif %}">
                         Cash
                     </a>
                 </div>


### PR DESCRIPTION
- Updated the /leaderboard route in Flask to display the ranked users in a table format.
- Users rank switching between **Cash Ranking** and **Total Asset Ranking**.
- Loops through each user, updates the table with rank, username, and cash value, and highlights the currently logged-in user.
- Styled leaderboard to match the Dashboard design system- reused panel layout, colour scheme and typography. Newly added rounded card, soft shadows and consistent spacing.
- Added media queries for mobile support.


Notes:
Currently using hardcoded data for testing because the latest changes containing the user model have not been merged yet.
Total assets temporarily use cash as a placeholder; once the asset tables are implemented, this will be updated.
