### PR TITLE
Add pagination to users page with improved structure

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,15 @@
 from flask import Flask, render_template, request, redirect, session, flash
 from db import init_db
 from models import db, User
-from user_service import get_all_users
+from user_service import get_users_paginated
 import hashlib
 
 app = Flask(__name__)
 app.secret_key = "secret123"
 init_db(app)
 
-# login
+
+# LOGIN
 @app.route("/login", methods=["GET", "POST"])
 def login():
     if request.method == "POST":
@@ -34,7 +35,8 @@ def login():
 
     return render_template("login.html")
 
-# register
+
+# REGISTER
 @app.route("/register", methods=["GET", "POST"])
 def register():
     if request.method == "POST":
@@ -59,7 +61,7 @@ def register():
         )
         db.session.add(new_user)
         db.session.commit()
-        
+
         session["user"] = new_user.username
         session["user_id"] = new_user.id
         session["username"] = new_user.username
@@ -72,8 +74,7 @@ def register():
     return render_template("register.html")
 
 
-
-# Home page
+# HOME
 @app.route("/")
 def home():
     if "user" in session:
@@ -81,6 +82,7 @@ def home():
     return redirect("/login")
 
 
+# DASHBOARD
 @app.route("/dashboard")
 def dashboard():
     if "user" not in session:
@@ -88,6 +90,7 @@ def dashboard():
     return render_template("dashboard.html")
 
 
+# LEADERBOARD
 @app.route("/leaderboard")
 def leaderboard():
     if "user" not in session:
@@ -95,16 +98,26 @@ def leaderboard():
     return render_template("leaderboard.html")
 
 
+# USERS WITH PAGINATION
 @app.route("/users")
 def users():
     if "user" not in session:
         return redirect("/login")
 
-    user_list = get_all_users()
-    return render_template("users.html", users=user_list)
+    page = request.args.get("page", 1, type=int)
+
+    data = get_users_paginated(page=page)
+
+    return render_template(
+        "users.html",
+        users=data["users"],
+        has_next=data["has_next"],
+        has_prev=data["has_prev"],
+        page=data["page"]
+    )
 
 
-# logout
+# LOGOUT
 @app.route("/logout")
 def logout():
     session.pop("user", None)

--- a/templates/users.html
+++ b/templates/users.html
@@ -5,20 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>All Users</title>
 
-    <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
 
 <div class="container mt-5">
+
     <div class="d-flex justify-content-between align-items-center mb-4">
         <a href="/dashboard" class="btn btn-secondary">
             ← Back to Dashboard
         </a>
-        <h1 class="mb-4">All Users</h1>
+        <h1 class="mb-0">All Users</h1>
     </div>
 
-    <!-- Search Bar -->
+    <!-- Search -->
     <input
         type="text"
         class="form-control mb-3"
@@ -27,7 +27,7 @@
         onkeyup="filterUsers()"
     >
 
-    <!-- Users Table -->
+    <!-- Table -->
     <table class="table table-striped table-bordered table-hover">
         <thead class="table-dark">
             <tr>
@@ -37,6 +37,7 @@
                 <th>Join Time</th>
             </tr>
         </thead>
+
         <tbody id="userTableBody">
             {% if users|length == 0 %}
             <tr>
@@ -54,6 +55,18 @@
             {% endif %}
         </tbody>
     </table>
+
+    <!-- Pagination -->
+    <div class="d-flex justify-content-between mt-3">
+        {% if has_prev %}
+            <a href="/users?page={{ page - 1 }}" class="btn btn-secondary">Previous</a>
+        {% endif %}
+
+        {% if has_next %}
+            <a href="/users?page={{ page + 1 }}" class="btn btn-secondary">Next</a>
+        {% endif %}
+    </div>
+
 </div>
 
 <script src="/static/js/users.js"></script>

--- a/user_service.py
+++ b/user_service.py
@@ -1,15 +1,19 @@
 from models import User
 
+def get_users_paginated(page=1, per_page=5):
+    users = User.query.order_by(User.created_at.asc()).paginate(page=page, per_page=per_page)
 
-def get_all_users():
-    users = User.query.order_by(User.created_at.desc()).all()
-
-    return [
-        {
-            "id": user.id,
-            "username": user.username,
-            "email": user.email,
-            "joinTime": user.created_at.strftime("%d %b %Y, %I:%M %p"),
-        }
-        for user in users
-    ]
+    return {
+        "users": [
+            {
+                "id": user.id,
+                "username": user.username,
+                "email": user.email,
+                "joinTime": user.created_at.strftime("%d %b %Y, %I:%M %p"),
+            }
+            for user in users.items
+        ],
+        "has_next": users.has_next,
+        "has_prev": users.has_prev,
+        "page": page
+    }


### PR DESCRIPTION
Closes #38 

This PR adds pagination support to the users page to improve performance and usability.

Previously, all users were displayed at once, which could become inefficient as the number of users grows. With this update:

- Users are now loaded in smaller batches per page
- Added "Next" and "Previous" buttons for navigation
- Updated backend logic to fetch users using paginated database queries
- Kept the existing search functionality working alongside pagination

This makes the users page more scalable and easier to navigate.