### PR TITLE
Updated the leaderboard to rank users based on Profit and Return Percentage and improve leaderboard calculatation logic

### DIFF
--- a/leaderboard.py
+++ b/leaderboard.py
@@ -1,6 +1,8 @@
 from models import User
 from trading_service import build_portfolio
 
+INITIAL_CASH = 10000.0
+
 def get_leaderboard_context(ranking_type, current_user):
 
     users = User.query.all()
@@ -8,25 +10,46 @@ def get_leaderboard_context(ranking_type, current_user):
     leaderboard_users = []
 
     for user in users:
-        if ranking_type == "assets":
-            portfolio = build_portfolio(user.id)
-            ranking_value = portfolio.get("totalAssets", 0.0)
-        else:
-            ranking_value = float(user.cash)
+        portfolio = build_portfolio(user.id)
 
-    
+        cash = float(portfolio.get("cash", user.cash))
+        total_assets = float(portfolio.get("totalAssets", cash))
+        total_profit = float(portfolio.get("totalProfit", 0.0))
+
+        if ranking_type == "assets":
+            ranking_value = total_assets
+        elif ranking_type == "profit":
+            ranking_value = total_profit
+        elif ranking_type == "return":
+            ranking_value = (total_assets - INITIAL_CASH) / INITIAL_CASH * 100
+        else:
+            ranking_value = cash
+            ranking_type
+
         leaderboard_users.append({
         "username": user.username,
         "email": user.email,
-        "cash": float(user.cash),
+        "cash": cash,
+        "total_assets": total_assets,
+        "total_profit": total_profit,
+        "returnPercent": (total_assets - INITIAL_CASH) / INITIAL_CASH * 100,
         "ranking_value": ranking_value
     })
 
     leaderboard_users.sort(key=lambda user: user["ranking_value"], reverse=True)
 
+    for index, user in enumerate(leaderboard_users, start=1):
+        user["rank"] = index
+
     if ranking_type == "assets":
         title = "Total Assets Ranking"
         value_label = "Total Assets"
+    elif ranking_type == "profit":
+        title = "Profit Ranking"
+        value_label = "Total Profit"
+    elif ranking_type == "return":
+        title = "Return Percentage Ranking"
+        value_label = "Return %"
     else:
         title = "Cash Ranking"
         value_label = "Cash"

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -3,6 +3,33 @@ from trading_service import build_portfolio
 
 INITIAL_CASH = 10000.0
 
+def calculate_user_metrics(user):
+    portfolio = build_portfolio(user.id)
+
+    cash = float(portfolio.get("cash", user.cash))
+    total_assets = float(portfolio.get("totalAssets", cash))
+    total_profit = float(portfolio.get("totalProfit", 0.0))
+    return_percent = (total_assets - INITIAL_CASH) / INITIAL_CASH * 100
+    
+    return {
+        "username": user.username,
+        "email": user.email,
+        "cash": cash,
+        "total_assets": total_assets,
+        "total_profit": total_profit,  
+        "returnPercent": return_percent
+    }
+
+def get_ranking_value(user_data, ranking_type):
+    if ranking_type == "assets":
+        return user_data["total_assets"]
+    elif ranking_type == "profit":
+        return user_data["total_profit"]
+    elif ranking_type == "return":
+        return user_data["returnPercent"]
+    else:
+        return user_data["cash"]
+    
 def get_leaderboard_context(ranking_type, current_user):
 
     users = User.query.all()
@@ -10,31 +37,12 @@ def get_leaderboard_context(ranking_type, current_user):
     leaderboard_users = []
 
     for user in users:
-        portfolio = build_portfolio(user.id)
 
-        cash = float(portfolio.get("cash", user.cash))
-        total_assets = float(portfolio.get("totalAssets", cash))
-        total_profit = float(portfolio.get("totalProfit", 0.0))
+        user_data = calculate_user_metrics(user)
+        
+        user_data["ranking_value"] = get_ranking_value(user_data, ranking_type)
 
-        if ranking_type == "assets":
-            ranking_value = total_assets
-        elif ranking_type == "profit":
-            ranking_value = total_profit
-        elif ranking_type == "return":
-            ranking_value = (total_assets - INITIAL_CASH) / INITIAL_CASH * 100
-        else:
-            ranking_value = cash
-            ranking_type
-
-        leaderboard_users.append({
-        "username": user.username,
-        "email": user.email,
-        "cash": cash,
-        "total_assets": total_assets,
-        "total_profit": total_profit,
-        "returnPercent": (total_assets - INITIAL_CASH) / INITIAL_CASH * 100,
-        "ranking_value": ranking_value
-    })
+        leaderboard_users.append(user_data)
 
     leaderboard_users.sort(key=lambda user: user["ranking_value"], reverse=True)
 

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -86,7 +86,11 @@
                                 </td>
                                 
                                 <td>{{ user.username }}</td>
-                                <td>${{ "{:,.2f}".format(user.ranking_value) }}</td>
+                                {% if ranking_type == "return" %}
+                                    {{ "%.2f"|format(user.ranking_value) }}%
+                                {% else %}
+                                    ${{ "%.2f"|format(user.ranking_value) }}
+                                {% endif %}
                             </tr>
                             {% endfor %}
                         {% else %}

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -45,6 +45,17 @@
                         class="ranking-tab {% if ranking_type == 'cash' %}active{% endif %}">
                         Cash
                     </a>
+
+                    <a href="{{ url_for('leaderboard', type='profit') }}"
+                        class="ranking-tab {% if ranking_type == 'profit' %}active{% endif %}">
+                        Profit
+                    </a>
+
+                    <a href="{{ url_for('leaderboard', type='return') }}"
+                        class="ranking-tab {% if ranking_type == 'return' %}active{% endif %}">
+                        Return %
+                    </a>
+
                 </div>
             </div>
 

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -86,11 +86,13 @@
                                 </td>
                                 
                                 <td>{{ user.username }}</td>
-                                {% if ranking_type == "return" %}
-                                    {{ "%.2f"|format(user.ranking_value) }}%
-                                {% else %}
-                                    ${{ "%.2f"|format(user.ranking_value) }}
-                                {% endif %}
+                                <td>
+                                    {% if ranking_type == "return" %}
+                                        {{ "%.2f"|format(user.ranking_value) }}%
+                                    {% else %}
+                                        ${{ "%.2f"|format(user.ranking_value) }}
+                                    {% endif %}
+                                </td>
                             </tr>
                             {% endfor %}
                         {% else %}


### PR DESCRIPTION
## Summary

This PR extends the leaderboard functionality by adding:

* Total Assets ranking
* Profit-based ranking
* Return percentage ranking

It also improves the internal leaderboard calculation structure by refactoring repeated portfolio calculation logic into smaller helper functions for better readability and maintainability.

---

## Implementation Details

* Reused the existing `build_portfolio()` function to calculate:

  * total assets
  * total profit
  * return percentage

* Added dynamic leaderboard sorting based on selected ranking type

* Updated leaderboard UI to correctly display currency and percentage values

* Added safe fallback handling using `.get()` to avoid potential KeyErrors

* Refactored leaderboard calculation logic into helper functions:
  
  * `calculate_user_metrics()`
  * `get_ranking_value()`

* Reduced repeated calculation logic inside `get_leaderboard_context()`

* Improved code readability and separation of responsibilities to make future optimization and maintenance easier

---

## Notes

* Total assets = cash balance + current stock holdings value

* Total profit = realized profit + unrealized profit

* Return % = ((totalAssets - initialCash) / initialCash) * 100

* Current refactor improves maintainability and prepares the leaderboard system for future performance optimizations

---

Resolves #44  
Resolves #63 