### PR TITLE
Fix Account Deletion Failure Due to Flask-Login LocalProxy

### DIFF
--- a/app.py
+++ b/app.py
@@ -460,19 +460,28 @@ def update_hide_holdings():
     db.session.commit()
     return jsonify({"ok": True})
 
-
 # DELETE ACCOUNT
 @app.route("/delete_account", methods=["POST"])
 @login_required
 def delete_account():
     password = request.form.get("password")
-    if not check_password_hash(current_user.password_hash, password):
+
+    user = User.query.get(current_user.id)
+
+    if not user:
+        flash("User not found.")
+        return redirect(url_for("login"))
+
+    if not check_password_hash(user.password_hash, password):
         flash("Password confirmation failed.")
         return redirect(url_for("profile"))
-    user = current_user
+
     logout_user()
+
     db.session.delete(user)
     db.session.commit()
+
+    flash("Account deleted successfully.")
     return redirect(url_for("register"))
 
 # LOGOUT


### PR DESCRIPTION
# Fix Account Deletion Failure Due to Flask-Login LocalProxy

## Summary

This PR fixes a server error that occurred when users attempted to delete their accounts.

Previously, the `delete_account` route attempted to pass Flask-Login’s `current_user` proxy object directly into `db.session.delete()`, which caused SQLAlchemy to raise an `UnmappedInstanceError`.

## Problem

The application produced the following error during account deletion:

```python
sqlalchemy.orm.exc.UnmappedInstanceError:
Class 'werkzeug.local.LocalProxy' is not mapped
```

This happened because:

```python
db.session.delete(current_user)
```

was attempting to delete a Flask-Login `LocalProxy` object rather than an actual SQLAlchemy `User` model instance.

## Changes Made

* Refactored the `delete_account` route to retrieve the actual `User` instance from the database using:

  ```python
  User.query.get(current_user.id)
  ```
* Added validation to ensure the user exists before deletion
* Updated password verification to use the retrieved `User` object
* Preserved logout functionality before account removal
* Added success/error flash message handling

## Expected Outcome

* Users can successfully delete their accounts
* No SQLAlchemy mapping errors occur
* User sessions are safely terminated before deletion
* Application redirects correctly after deletion

Resolves #113 
