### PR TITLE
Update duplicate registration Selenium test for WTForms validation

### DIFF
--- a/tests/selenium/test_register.py
+++ b/tests/selenium/test_register.py
@@ -61,16 +61,21 @@ def test_duplicate_username_or_email_shows_error(driver):
     driver.get(f"{BASE_URL}/register")
 
     driver.find_element(By.NAME, "username").send_keys("testuser1")
-    driver.find_element(By.NAME, "email").send_keys("testuser1@example.com")
+    driver.find_element(By.NAME, "email").send_keys("testuser1@gmail.com")
     driver.find_element(By.NAME, "password").send_keys("Testuser1")
 
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
 
     WebDriverWait(driver, 5).until(
-        EC.presence_of_element_located((By.TAG_NAME, "body"))
+        EC.presence_of_element_located((By.CLASS_NAME, "flash-msg"))
     )
 
-    assert "username or email already exists" in driver.page_source.lower()
+    page = driver.page_source.lower()
+
+    assert (
+        "username already exists" in page
+        or "email already exists" in page
+    )
 
 
 def test_empty_register_form_stays_on_register_page(driver):


### PR DESCRIPTION
## Summary

This PR updates the Selenium registration test for duplicate user validation to correctly match the current WTForms validation flow implemented in the application.

Previously, the Selenium test expected the duplicate-registration error message:

```text
Username or email already exists.
```

The test assumed the backend route-level `flash()` message would be rendered after duplicate registration attempts.

However, further investigation showed that duplicate username/email validation is already handled earlier inside `RegisterForm` through custom WTForms validators:

* `validate_username()`
* `validate_email()`

Because these validators run during `form.validate_on_submit()`, the request does not reach the route-level duplicate `flash()` block. Instead, WTForms directly generates validation messages such as:

```text
Username already exists.
```

or

```text
Email already exists.
```

## Changes Made

Updated the Selenium duplicate-registration test to validate the actual WTForms validation messages rendered by the registration page.

### Previous Assertion

```python
assert "username or email already exists" in driver.page_source.lower()
```

### Updated Assertion

```python
assert (
    "username already exists" in page
    or "email already exists" in page
)
```

## Result

* Selenium registration tests now correctly reflect the application's current validation behaviour.
* Duplicate registration validation is successfully tested without modifying backend logic.
* Test reliability and consistency have been improved.

Closes #110 
